### PR TITLE
No country should lack a name, dialCode or alpha2Code

### DIFF
--- a/lib/src/country_codes.dart
+++ b/lib/src/country_codes.dart
@@ -52,15 +52,17 @@ class CountryCodes {
   }
 
   /// A list of dial codes for every country
-  static List<String?> dialNumbers() {
+  static List<String> dialNumbers() {
     return codes.values
         .map((each) => CountryDetails.fromMap(each).dialCode)
         .toList();
   }
 
   /// A list of country data for every country
-  static List<CountryDetails?> countryCodes() {
-    return codes.values.map((each) => CountryDetails.fromMap(each)).toList();
+  static List<CountryDetails> countryCodes() {
+    return codes.values
+        .map((each) => CountryDetails.fromMap(each))
+        .toList();
   }
 
   /// Returns the `CountryDetails` for the given [locale]. If not provided,

--- a/lib/src/country_details.dart
+++ b/lib/src/country_details.dart
@@ -1,11 +1,11 @@
 class CountryDetails {
   /// Dial code represents a global phone prefix for the region
   /// Example: `+1`, `+351`
-  final String? dialCode;
+  final String dialCode;
 
   /// ISO 3166 alpha 2 code
   /// Example: `US`, `PT`
-  final String? alpha2Code;
+  final String alpha2Code;
 
   /// ISO 3166 alpha 3 code
   /// Example: `USA`, `PRT`
@@ -17,7 +17,7 @@ class CountryDetails {
   /// US : United States
   /// IT : Italia
   /// DE : Deutschland
-  final String? name;
+  final String name;
 
   /// Extended country name based on a region language
   ///

--- a/test/country_codes_test.dart
+++ b/test/country_codes_test.dart
@@ -1,1 +1,10 @@
-void main() {}
+import 'package:country_codes/country_codes.dart';
+import 'package:country_codes/src/codes.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('No Country lacks name,alphaCode2 and dialCode', () {
+    final numberOfParsedCountries = CountryCodes.countryCodes().length;
+    expect(numberOfParsedCountries, codes.values.length);
+  });
+}


### PR DESCRIPTION
For data accuracy on `CountryDetails` i thought no country could lack a name, dialCode or alpha2Code, 

This will reduce the number of null checks to do around the three.
i also added a unit test to make sure of this.