### PR TITLE
Resolved issue where "NewApi" build error occurred in API version 21 …

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,4 +49,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+
+    implementation 'org.apache.commons:commons-lang3:3.6'
 }


### PR DESCRIPTION
Resolved issue where "NewApi" build error occurred in API version 21 or lower.

toLanguageTag and forLanguageTag of Locale is support from API level 21 and minSdkVersion is 16.
Modify to branch code based on build version.