### PR TITLE
Fix error in CountryCodes#detailsFromAlpha2

### DIFF
--- a/lib/src/country_codes.dart
+++ b/lib/src/country_codes.dart
@@ -85,7 +85,7 @@ class CountryCodes {
 
   /// Returns the `CountryDetails` for the given country alpha2 code.
   static CountryDetails detailsFromAlpha2(String alpha2) {
-    var codeEntry = codes.entries.where((entry) => entry.key == alpha2).single;
+    MapEntry<String, dynamic> codeEntry = codes.entries.where((entry) => entry.key == alpha2).single;
     return CountryDetails.fromMap(codeEntry.value, _localizedCountryNames[codeEntry.key]);
   }
 

--- a/lib/src/country_codes.dart
+++ b/lib/src/country_codes.dart
@@ -85,7 +85,8 @@ class CountryCodes {
 
   /// Returns the `CountryDetails` for the given country alpha2 code.
   static CountryDetails detailsFromAlpha2(String alpha2) {
-    return CountryDetails.fromMap(codes.entries.where((entry) => entry.key == alpha2).single.value);
+    var codeEntry = codes.entries.where((entry) => entry.key == alpha2).single;
+    return CountryDetails.fromMap(codeEntry.value, _localizedCountryNames[codeEntry.key]);
   }
 
   /// Returns the ISO 3166-1 `alpha2Code` for the given [locale].


### PR DESCRIPTION
Fixes #37

Update `CountryCodes#detailsFromAlpha2` to include `localizedCountryName` parameter in `CountryDetails#fromMap` call.

* Retrieve `localizedCountryName` from `_localizedCountryNames` using the `alpha2` key.
* Pass the `localizedCountryName` parameter to the `CountryDetails#fromMap` call.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/miguelpruivo/country_codes/pull/54?shareId=98ac80ff-5da2-4129-a338-e718961a8491).